### PR TITLE
Fix jobs migration

### DIFF
--- a/src/Domain/Command/MysqlEscaper.php
+++ b/src/Domain/Command/MysqlEscaper.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\PimMigration\Domain\Command;
+
+use Akeneo\PimMigration\Domain\Pim\Pim;
+
+/**
+ * Escapes a string to use it in as parameter in a MySQL query.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ */
+interface MysqlEscaper
+{
+    /**
+     * Escapes a string for a given PIM.
+     */
+    public function escape(string $stringToEscape, Pim $pim): string;
+}

--- a/src/Domain/MigrationStep/s100_JobMigration/JobMigrator.php
+++ b/src/Domain/MigrationStep/s100_JobMigration/JobMigrator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\PimMigration\Domain\MigrationStep\s100_JobMigration;
 
 use Akeneo\PimMigration\Domain\Command\ChainedConsole;
+use Akeneo\PimMigration\Domain\Command\MysqlEscaper;
 use Akeneo\PimMigration\Domain\Command\MySqlExecuteCommand;
 use Akeneo\PimMigration\Domain\Command\MySqlQueryCommand;
 use Akeneo\PimMigration\Domain\DataMigration\DataMigrationException;
@@ -26,9 +27,13 @@ class JobMigrator
     /** @var ChainedConsole */
     private $console;
 
-    public function __construct(ChainedConsole $console)
+    /** @var MysqlEscaper */
+    private $mysqlEscaper;
+
+    public function __construct(ChainedConsole $console, MysqlEscaper $mysqlEscaper)
     {
         $this->console = $console;
+        $this->mysqlEscaper = $mysqlEscaper;
     }
 
     /**
@@ -193,9 +198,9 @@ class JobMigrator
 
         return array_map(function ($migratedJobInstance) use ($destinationPim) {
             return sprintf(
-                "UPDATE %s.akeneo_batch_job_instance SET raw_parameters = '%s' WHERE code = '%s'",
+                "UPDATE %s.akeneo_batch_job_instance SET raw_parameters = %s WHERE code = '%s'",
                 $destinationPim->getDatabaseName(),
-                $migratedJobInstance['raw_parameters'],
+                $this->mysqlEscaper->escape($migratedJobInstance['raw_parameters'], $destinationPim),
                 $migratedJobInstance['code']
             );
         }, $migratedJobInstances);

--- a/src/Domain/MigrationStep/s100_JobMigration/JobMigrator.php
+++ b/src/Domain/MigrationStep/s100_JobMigration/JobMigrator.php
@@ -44,7 +44,7 @@ class JobMigrator
             $queries = [];
 
             $queries[] = sprintf(
-                'ALTER TABLE %s.akeneo_batch_job_execution ADD COLUMN raw_parameters LONGTEXT NOT NULL AFTER log_file',
+                'ALTER TABLE %s.akeneo_batch_job_execution ADD COLUMN raw_parameters LONGTEXT NOT NULL AFTER log_file, ADD COLUMN health_check_time DATETIME NULL AFTER updated_time',
                 $destinationPim->getDatabaseName()
             );
 

--- a/src/Infrastructure/Cli/LocalMySqlQueryExecutor.php
+++ b/src/Infrastructure/Cli/LocalMySqlQueryExecutor.php
@@ -39,7 +39,7 @@ class LocalMySqlQueryExecutor
         return $pdo->query($sql)->fetchAll(\PDO::FETCH_ASSOC);
     }
 
-    protected function getConnection(Pim $pim): \PDO
+    public function getConnection(Pim $pim): \PDO
     {
         $dsn = sprintf(
             'mysql: host=%s;dbname=%s;port=%s',

--- a/src/Infrastructure/Cli/LocalMysqlEscaper.php
+++ b/src/Infrastructure/Cli/LocalMysqlEscaper.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\PimMigration\Infrastructure\Cli;
+
+use Akeneo\PimMigration\Domain\Command\MysqlEscaper;
+use Akeneo\PimMigration\Domain\Pim\Pim;
+
+/**
+ * Class LocalMysqlEscaper
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ */
+class LocalMysqlEscaper implements MysqlEscaper
+{
+    /** @var LocalMySqlQueryExecutor */
+    private $mysqlQueryExecutor;
+
+    public function __construct(LocalMySqlQueryExecutor $mysqlQueryExecutor)
+    {
+        $this->mysqlQueryExecutor = $mysqlQueryExecutor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function escape(string $stringToEscape, Pim $pim): string
+    {
+        $mysqlConnection = $this->mysqlQueryExecutor->getConnection($pim);
+
+        return $mysqlConnection->quote($stringToEscape);
+    }
+}

--- a/src/Infrastructure/Common/config/services.yml
+++ b/src/Infrastructure/Common/config/services.yml
@@ -24,6 +24,9 @@ services:
   Akeneo\PimMigration\Infrastructure\Cli\LocalConsole: ~
   Akeneo\PimMigration\Infrastructure\Cli\SshConsole: ~
 
+  Akeneo\PimMigration\Domain\Command\MysqlEscaper:
+    class: 'Akeneo\PimMigration\Infrastructure\Cli\LocalMysqlEscaper'
+
 ### DATA MIGRATION
   Akeneo\PimMigration\Domain\DataMigration\BundleConfigFetcher: ~
   Akeneo\PimMigration\Domain\DataMigration\EntityMappingChecker: ~

--- a/tests/spec/Domain/MigrationStep/s100_JobMigration/JobMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s100_JobMigration/JobMigratorSpec.php
@@ -6,6 +6,7 @@ namespace spec\Akeneo\PimMigration\Domain\MigrationStep\s100_JobMigration;;
 
 use Akeneo\PimMigration\Domain\Command\ChainedConsole;
 use Akeneo\PimMigration\Domain\Command\CommandResult;
+use Akeneo\PimMigration\Domain\Command\MysqlEscaper;
 use Akeneo\PimMigration\Domain\Command\MySqlExecuteCommand;
 use Akeneo\PimMigration\Domain\Command\MySqlQueryCommand;
 use Akeneo\PimMigration\Domain\DataMigration\DatabaseQueryExecutor;
@@ -26,9 +27,9 @@ use PhpSpec\ObjectBehavior;
  */
 class JobMigratorSpec extends ObjectBehavior
 {
-    public function let(ChainedConsole $console)
+    public function let(ChainedConsole $console, MysqlEscaper $mysqlEscaper)
     {
-        $this->beConstructedWith($console);
+        $this->beConstructedWith($console, $mysqlEscaper);
     }
 
     public function it_is_initializable()
@@ -42,7 +43,8 @@ class JobMigratorSpec extends ObjectBehavior
         SourcePim $sourcePim,
         DestinationPim $destinationPim,
         CommandResult $commandResult,
-        $console
+        $console,
+        $mysqlEscaper
     ) {
         $this->addJobMigrator($migratorOne);
         $this->addJobMigrator($migratorTwo);
@@ -70,6 +72,8 @@ class JobMigratorSpec extends ObjectBehavior
         $parameters['user_to_notify'] = null;
         $parameters['is_user_authenticated'] = false;
         $parameters = serialize($parameters);
+
+        $mysqlEscaper->escape($parameters, $destinationPim)->willReturn("'".$parameters."'");
 
         $query = sprintf("UPDATE database_name.akeneo_batch_job_instance SET raw_parameters = '%s' WHERE code = 'add_product_value'", $parameters);
 

--- a/tests/spec/Domain/MigrationStep/s100_JobMigration/JobMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s100_JobMigration/JobMigratorSpec.php
@@ -53,7 +53,7 @@ class JobMigratorSpec extends ObjectBehavior
         $destinationPim->getDatabaseName()->willReturn('database_name');
 
         $console->execute(
-            new MySqlExecuteCommand('ALTER TABLE database_name.akeneo_batch_job_execution ADD COLUMN raw_parameters LONGTEXT NOT NULL AFTER log_file'),
+            new MySqlExecuteCommand('ALTER TABLE database_name.akeneo_batch_job_execution ADD COLUMN raw_parameters LONGTEXT NOT NULL AFTER log_file, ADD COLUMN health_check_time DATETIME NULL AFTER updated_time'),
             $destinationPim
         )->shouldBeCalled();
 


### PR DESCRIPTION
A new column in table akeneo_batch_job_execution was missing during jobs migration.

The column `akeneo_batch_job_instance.raw_values` is updated but it needs to be escaped because of the backslashes.