### PR TITLE
ISSUE-84: Fix missing internal job instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - GITHUB-74 Add possibility to define defaults responses
 - Fix MySQL query parameter that needs to be escaped
 - GITHUB-78 Add support for null as database password
+- GITHUB-84 Fix missing internal job instance
 
 # 1.0.0-alpha1
 

--- a/src/Domain/MigrationStep/s100_JobMigration/JobMigrator.php
+++ b/src/Domain/MigrationStep/s100_JobMigration/JobMigrator.php
@@ -53,6 +53,8 @@ class JobMigrator
                 $destinationPim->getDatabaseName()
             );
 
+            $queries[] = "INSERT INTO akeneo_batch_job_instance (code,label,job_name,status,connector,raw_parameters,type) VALUES ('compute_product_models_descendants','Compute product models descendants','compute_product_models_descendants',0,'internal','a:0:{}','compute_product_models_descendants')";
+
             $queries = array_merge($queries, $this->getUpdateJobInstanceQueries($destinationPim));
 
             foreach ($queries as $query) {

--- a/tests/spec/Domain/MigrationStep/s100_JobMigration/JobMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s100_JobMigration/JobMigratorSpec.php
@@ -59,6 +59,11 @@ class JobMigratorSpec extends ObjectBehavior
             $destinationPim
         )->shouldBeCalled();
 
+        $console->execute(
+            new MySqlExecuteCommand("INSERT INTO akeneo_batch_job_instance (code,label,job_name,status,connector,raw_parameters,type) VALUES ('compute_product_models_descendants','Compute product models descendants','compute_product_models_descendants',0,'internal','a:0:{}','compute_product_models_descendants'"),
+            $destinationPim
+        )->shouldBeCalled();
+
         $rawParameters = 'a:7:{s:8:"filePath";s:25:"/tmp/association_type.csv";s:9:"delimiter";s:1:";";s:9:"enclosure";s:1:""";s:6:"escape";s:1:"\";s:10:"withHeader";b:1;s:13:"uploadAllowed";b:1;s:25:"invalid_items_file_format";s:3:"csv";}';
 
         $commandResult->getOutput()->willReturn([['code' => 'add_product_value', 'raw_parameters' => $rawParameters]]);


### PR DESCRIPTION
The internal job compute_product_models_descendants has been added in 2.0, but it's missing after a full migration.

The job can't be created with the command `akeneo:batch:create-job`, so we have to add it with a SQL query.