### PR TITLE
ISSUE-79: remove useless usage of database name in MySQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix MySQL query parameter that needs to be escaped
 - GITHUB-78 Add support for null as database password
 - GITHUB-84 Fix missing internal job instance
+- GITHUB-79 Remove useless usage of database name in MySQL queries
 
 # 1.0.0-alpha1
 

--- a/src/Domain/MigrationStep/s070_StructureMigration/AttributeDataMigrator.php
+++ b/src/Domain/MigrationStep/s070_StructureMigration/AttributeDataMigrator.php
@@ -35,17 +35,17 @@ class AttributeDataMigrator implements DataMigrator
     {
         $tableName = 'pim_catalog_attribute';
 
-        $sqlUpdate = 'UPDATE %s.%s SET backend_type = "%s" WHERE backend_type = "%s"';
+        $sqlUpdate = 'UPDATE %s SET backend_type = "%s" WHERE backend_type = "%s"';
 
         try {
             $this->tableMigrator->migrate($sourcePim, $destinationPim, $tableName);
 
             $this->chainedConsole->execute(
-                new MySqlExecuteCommand(sprintf($sqlUpdate, $destinationPim->getDatabaseName(), $tableName, 'textarea', 'text')), $destinationPim
+                new MySqlExecuteCommand(sprintf($sqlUpdate, $tableName, 'textarea', 'text')), $destinationPim
             );
 
             $this->chainedConsole->execute(
-                new MySqlExecuteCommand(sprintf($sqlUpdate, $destinationPim->getDatabaseName(), $tableName, 'text', 'varchar')), $destinationPim
+                new MySqlExecuteCommand(sprintf($sqlUpdate, $tableName, 'text', 'varchar')), $destinationPim
             );
         } catch (\Exception $exception) {
             throw new StructureMigrationException($exception->getMessage(), $exception->getCode(), $exception);

--- a/src/Domain/MigrationStep/s080_FamilyMigration/FamilyDataMigrator.php
+++ b/src/Domain/MigrationStep/s080_FamilyMigration/FamilyDataMigrator.php
@@ -47,8 +47,7 @@ class FamilyDataMigrator implements DataMigrator
 
             $this->chainedConsole->execute(
                 new MySqlExecuteCommand(sprintf(
-                    'ALTER TABLE %s.%s %s, %s, %s',
-                    $destinationPim->getDatabaseName(),
+                    'ALTER TABLE %s %s, %s, %s',
                     $tableName,
                     $sqlAddColumnPart,
                     $sqlAddAttributeFkPart,

--- a/src/Domain/MigrationStep/s090_SystemMigration/SystemMigrator.php
+++ b/src/Domain/MigrationStep/s090_SystemMigration/SystemMigrator.php
@@ -40,20 +40,14 @@ class SystemMigrator
             }
 
             $queries = [];
-            $queries[] = sprintf(
-                'ALTER TABLE %1$s.pim_api_access_token
+            $queries[] =
+                'ALTER TABLE pim_api_access_token
                 ADD COLUMN client int(11) DEFAULT NULL AFTER id,
-                ADD CONSTRAINT FK_BD5E4023C7440455 FOREIGN KEY (client) REFERENCES %1$s.pim_api_client (id) ON DELETE CASCADE;',
-                $destinationPim->getDatabaseName()
-            );
-            $queries[] = sprintf(
-                'CREATE INDEX IDX_BD5E4023C7440455 ON %s.pim_api_access_token (client);',
-                $destinationPim->getDatabaseName()
-            );
-            $queries[] = sprintf(
-                'UPDATE %s.pim_api_client SET label = id WHERE label IS NULL;',
-                $destinationPim->getDatabaseName()
-            );
+                ADD CONSTRAINT FK_BD5E4023C7440455 FOREIGN KEY (client) REFERENCES pim_api_client (id) ON DELETE CASCADE;';
+
+            $queries[] = 'CREATE INDEX IDX_BD5E4023C7440455 ON pim_api_access_token (client);';
+
+            $queries[] = 'UPDATE pim_api_client SET label = id WHERE label IS NULL;';
 
             foreach ($queries as $query) {
                 $this->console->execute(new MySqlExecuteCommand($query), $destinationPim);

--- a/src/Domain/MigrationStep/s100_JobMigration/JobMigrator.php
+++ b/src/Domain/MigrationStep/s100_JobMigration/JobMigrator.php
@@ -47,11 +47,7 @@ class JobMigrator
             }
 
             $queries = [];
-
-            $queries[] = sprintf(
-                'ALTER TABLE %s.akeneo_batch_job_execution ADD COLUMN raw_parameters LONGTEXT NOT NULL AFTER log_file, ADD COLUMN health_check_time DATETIME NULL AFTER updated_time',
-                $destinationPim->getDatabaseName()
-            );
+            $queries[] = 'ALTER TABLE akeneo_batch_job_execution ADD COLUMN raw_parameters LONGTEXT NOT NULL AFTER log_file, ADD COLUMN health_check_time DATETIME NULL AFTER updated_time';
 
             $queries[] = "INSERT INTO akeneo_batch_job_instance (code,label,job_name,status,connector,raw_parameters,type) VALUES ('compute_product_models_descendants','Compute product models descendants','compute_product_models_descendants',0,'internal','a:0:{}','compute_product_models_descendants')";
 
@@ -180,8 +176,7 @@ class JobMigrator
         ];
 
         $query = sprintf(
-            'SELECT code, raw_parameters FROM %s.akeneo_batch_job_instance WHERE code IN (%s)',
-            $destinationPim->getDatabaseName(),
+            'SELECT code, raw_parameters FROM akeneo_batch_job_instance WHERE code IN (%s)',
             implode(', ', $jobInstancesCode)
         );
 
@@ -200,8 +195,7 @@ class JobMigrator
 
         return array_map(function ($migratedJobInstance) use ($destinationPim) {
             return sprintf(
-                "UPDATE %s.akeneo_batch_job_instance SET raw_parameters = %s WHERE code = '%s'",
-                $destinationPim->getDatabaseName(),
+                "UPDATE akeneo_batch_job_instance SET raw_parameters = %s WHERE code = '%s'",
                 $this->mysqlEscaper->escape($migratedJobInstance['raw_parameters'], $destinationPim),
                 $migratedJobInstance['code']
             );

--- a/src/Domain/MigrationStep/s110_GroupMigration/GroupMigrator.php
+++ b/src/Domain/MigrationStep/s110_GroupMigration/GroupMigrator.php
@@ -45,7 +45,7 @@ class GroupMigrator implements DataMigrator
             }
 
             $this->chainedConsole->execute(
-                new MySqlExecuteCommand(sprintf('UPDATE %s.pim_catalog_group_type SET is_variant = 0', $destinationPim->getDatabaseName())), $destinationPim
+                new MySqlExecuteCommand('UPDATE pim_catalog_group_type SET is_variant = 0'), $destinationPim
             );
         } catch (\Exception $exception) {
             throw new GroupMigrationException($exception->getMessage(), $exception->getCode(), $exception);

--- a/src/Domain/MigrationStep/s140_ProductMigration/ProductMigrator.php
+++ b/src/Domain/MigrationStep/s140_ProductMigration/ProductMigrator.php
@@ -121,8 +121,7 @@ class ProductMigrator implements DataMigrator
             $creationDate = new \DateTime($product['created']);
 
             $command = new MySqlExecuteCommand(sprintf(
-                'UPDATE %s.pim_catalog_product SET created = "%s" WHERE identifier = "%s"',
-                $pim->getDatabaseName(),
+                'UPDATE pim_catalog_product SET created = "%s" WHERE identifier = "%s"',
                 $creationDate->format('Y-m-d H:i:s'),
                 $product['identifier']
             ));

--- a/src/Infrastructure/Cli/LocalMySqlQueryExecutor.php
+++ b/src/Infrastructure/Cli/LocalMySqlQueryExecutor.php
@@ -24,11 +24,7 @@ class LocalMySqlQueryExecutor
         try {
             $pdo->exec($sql);
         } catch (\PDOException $exception) {
-            throw new QueryException(
-                sprintf('Query "%s" occured an error : %s', $sql, $exception->getMessage()),
-                $exception->getCode(),
-                $exception
-            );
+            throw new QueryException(sprintf('Query "%s" occured an error : %s', $sql, $exception->getMessage()));
         }
     }
 

--- a/tests/spec/Domain/MigrationStep/s070_StructureMigration/AttributeDataMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s070_StructureMigration/AttributeDataMigratorSpec.php
@@ -52,14 +52,12 @@ class AttributeDataMigratorSpec extends ObjectBehavior
         $migrator,
         $chainedConsole
     ) {
-        $destinationPim->getDatabaseName()->willReturn('akeneo_pim_two_for_test');
-
         $migrator
             ->migrate($sourcePim, $destinationPim, 'pim_catalog_attribute')
             ->shouldBeCalled();
 
         $chainedConsole
-            ->execute(new MySqlExecuteCommand('UPDATE akeneo_pim_two_for_test.pim_catalog_attribute SET backend_type = "textarea" WHERE backend_type = "text"'), $destinationPim)
+            ->execute(new MySqlExecuteCommand('UPDATE pim_catalog_attribute SET backend_type = "textarea" WHERE backend_type = "text"'), $destinationPim)
             ->willThrow(QueryException::class);
 
         $this->shouldThrow(new StructureMigrationException())->during('migrate', [$sourcePim, $destinationPim]);
@@ -71,18 +69,16 @@ class AttributeDataMigratorSpec extends ObjectBehavior
         $migrator,
         $chainedConsole
     ) {
-        $destinationPim->getDatabaseName()->willReturn('akeneo_pim_two_for_test');
-
         $migrator
             ->migrate($sourcePim, $destinationPim, 'pim_catalog_attribute')
             ->shouldBeCalled();
 
         $chainedConsole
-            ->execute(new MySqlExecuteCommand('UPDATE akeneo_pim_two_for_test.pim_catalog_attribute SET backend_type = "textarea" WHERE backend_type = "text"'), $destinationPim)
+            ->execute(new MySqlExecuteCommand('UPDATE pim_catalog_attribute SET backend_type = "textarea" WHERE backend_type = "text"'), $destinationPim)
             ->shouldBeCalled();
 
         $chainedConsole
-            ->execute(new MySqlExecuteCommand('UPDATE akeneo_pim_two_for_test.pim_catalog_attribute SET backend_type = "text" WHERE backend_type = "varchar"'), $destinationPim)
+            ->execute(new MySqlExecuteCommand('UPDATE pim_catalog_attribute SET backend_type = "text" WHERE backend_type = "varchar"'), $destinationPim)
             ->willThrow(QueryException::class);
 
         $this->shouldThrow(new StructureMigrationException())->during('migrate', [$sourcePim, $destinationPim]);
@@ -94,18 +90,16 @@ class AttributeDataMigratorSpec extends ObjectBehavior
         $migrator,
         $chainedConsole
     ) {
-        $destinationPim->getDatabaseName()->willReturn('akeneo_pim_two_for_test');
-
         $migrator
             ->migrate($sourcePim, $destinationPim, 'pim_catalog_attribute')
             ->shouldBeCalled();
 
         $chainedConsole
-            ->execute(new MySqlExecuteCommand('UPDATE akeneo_pim_two_for_test.pim_catalog_attribute SET backend_type = "textarea" WHERE backend_type = "text"'), $destinationPim)
+            ->execute(new MySqlExecuteCommand('UPDATE pim_catalog_attribute SET backend_type = "textarea" WHERE backend_type = "text"'), $destinationPim)
             ->shouldBeCalled();
 
         $chainedConsole
-            ->execute(new MySqlExecuteCommand('UPDATE akeneo_pim_two_for_test.pim_catalog_attribute SET backend_type = "text" WHERE backend_type = "varchar"'), $destinationPim)
+            ->execute(new MySqlExecuteCommand('UPDATE pim_catalog_attribute SET backend_type = "text" WHERE backend_type = "varchar"'), $destinationPim)
             ->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);

--- a/tests/spec/Domain/MigrationStep/s080_FamilyMigration/FamilyDataMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s080_FamilyMigration/FamilyDataMigratorSpec.php
@@ -38,7 +38,6 @@ class FamilyDataMigratorSpec extends ObjectBehavior
         DestinationPim $destinationPim,
         $migrator
     ) {
-        $destinationPim->getDatabaseName()->willReturn('akeneo_pim_two_for_test');
         $migrator
             ->migrate($sourcePim, $destinationPim, 'pim_catalog_family')
             ->willThrow(DataMigrationException::class);
@@ -52,8 +51,6 @@ class FamilyDataMigratorSpec extends ObjectBehavior
         $chainedConsole,
         $migrator
     ) {
-        $destinationPim->getDatabaseName()->willReturn('akeneo_pim_two_for_test');
-
         $migrator
             ->migrate($sourcePim, $destinationPim, 'pim_catalog_family')
             ->shouldBeCalled();
@@ -63,8 +60,7 @@ class FamilyDataMigratorSpec extends ObjectBehavior
         $sqlAddKeyPart = 'ADD KEY `IDX_90632072BC295696` (`image_attribute_id`)';
 
         $sql = sprintf(
-            'ALTER TABLE %s.%s %s, %s, %s',
-            'akeneo_pim_two_for_test',
+            'ALTER TABLE %s %s, %s, %s',
             'pim_catalog_family',
             $sqlAddColumnPart,
             $sqlAddAttributeFkPart,
@@ -83,8 +79,6 @@ class FamilyDataMigratorSpec extends ObjectBehavior
         $chainedConsole,
         $migrator
     ) {
-        $destinationPim->getDatabaseName()->willReturn('akeneo_pim_two_for_test');
-
         $migrator
             ->migrate($sourcePim, $destinationPim, 'pim_catalog_family')
             ->shouldBeCalled();
@@ -95,8 +89,7 @@ class FamilyDataMigratorSpec extends ObjectBehavior
 
         $chainedConsole->execute(
             new MySqlExecuteCommand(sprintf(
-                'ALTER TABLE %s.%s %s, %s, %s',
-                'akeneo_pim_two_for_test',
+                'ALTER TABLE %s %s, %s, %s',
                 'pim_catalog_family',
                 $sqlAddColumnPart,
                 $sqlAddAttributeFkPart,

--- a/tests/spec/Domain/MigrationStep/s090_SystemMigration/SystemMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s090_SystemMigration/SystemMigratorSpec.php
@@ -45,23 +45,22 @@ class SystemMigratorSpec extends ObjectBehavior
         $migratorOne->migrate($sourcePim, $destinationPim)->shouldBeCalled();
         $migratorTwo->migrate($sourcePim, $destinationPim)->shouldBeCalled();
 
-        $destinationPim->getDatabaseName()->willReturn('database_name');
         $chainedConsole
             ->execute(new MySqlExecuteCommand(
-                'ALTER TABLE database_name.pim_api_access_token
+                'ALTER TABLE pim_api_access_token
                 ADD COLUMN client int(11) DEFAULT NULL AFTER id,
-                ADD CONSTRAINT FK_BD5E4023C7440455 FOREIGN KEY (client) REFERENCES database_name.pim_api_client (id) ON DELETE CASCADE;'
+                ADD CONSTRAINT FK_BD5E4023C7440455 FOREIGN KEY (client) REFERENCES pim_api_client (id) ON DELETE CASCADE;'
             ),
                 $destinationPim)
             ->shouldBeCalled();
 
         $chainedConsole
             ->execute(new MySqlExecuteCommand(
-                'CREATE INDEX IDX_BD5E4023C7440455 ON database_name.pim_api_access_token (client);'
+                'CREATE INDEX IDX_BD5E4023C7440455 ON pim_api_access_token (client);'
             ), $destinationPim)->shouldBeCalled();
 
         $chainedConsole->execute(
-            new MySqlExecuteCommand('UPDATE database_name.pim_api_client SET label = id WHERE label IS NULL;'),
+            new MySqlExecuteCommand('UPDATE pim_api_client SET label = id WHERE label IS NULL;'),
             $destinationPim)->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);

--- a/tests/spec/Domain/MigrationStep/s100_JobMigration/JobMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s100_JobMigration/JobMigratorSpec.php
@@ -52,10 +52,8 @@ class JobMigratorSpec extends ObjectBehavior
         $migratorOne->migrate($sourcePim, $destinationPim)->shouldBeCalled();
         $migratorTwo->migrate($sourcePim, $destinationPim)->shouldBeCalled();
 
-        $destinationPim->getDatabaseName()->willReturn('database_name');
-
         $console->execute(
-            new MySqlExecuteCommand('ALTER TABLE database_name.akeneo_batch_job_execution ADD COLUMN raw_parameters LONGTEXT NOT NULL AFTER log_file, ADD COLUMN health_check_time DATETIME NULL AFTER updated_time'),
+            new MySqlExecuteCommand('ALTER TABLE akeneo_batch_job_execution ADD COLUMN raw_parameters LONGTEXT NOT NULL AFTER log_file, ADD COLUMN health_check_time DATETIME NULL AFTER updated_time'),
             $destinationPim
         )->shouldBeCalled();
 
@@ -80,7 +78,7 @@ class JobMigratorSpec extends ObjectBehavior
 
         $mysqlEscaper->escape($parameters, $destinationPim)->willReturn("'".$parameters."'");
 
-        $query = sprintf("UPDATE database_name.akeneo_batch_job_instance SET raw_parameters = '%s' WHERE code = 'add_product_value'", $parameters);
+        $query = sprintf("UPDATE akeneo_batch_job_instance SET raw_parameters = '%s' WHERE code = 'add_product_value'", $parameters);
 
         $console->execute(new MySqlExecuteCommand($query), $destinationPim)->shouldBeCalled();
 
@@ -211,7 +209,7 @@ class JobMigratorSpec extends ObjectBehavior
         ];
 
         $query = sprintf(
-            'SELECT code, raw_parameters FROM database_name.akeneo_batch_job_instance WHERE code IN (%s)',
+            'SELECT code, raw_parameters FROM akeneo_batch_job_instance WHERE code IN (%s)',
             implode(', ', $jobInstancesCode)
         );
 

--- a/tests/spec/Domain/MigrationStep/s110_GroupMigration/GroupMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s110_GroupMigration/GroupMigratorSpec.php
@@ -43,10 +43,8 @@ class GroupMigratorSpec extends ObjectBehavior
         $groupMigratorOne->migrate($sourcePim, $destinationPim)->shouldBeCalled();
         $groupMigratorTwo->migrate($sourcePim, $destinationPim)->shouldBeCalled();
 
-        $destinationPim->getDatabaseName()->willReturn('database_name');
-
         $chainedConsole->execute(
-            new MySqlExecuteCommand('UPDATE database_name.pim_catalog_group_type SET is_variant = 0'),
+            new MySqlExecuteCommand('UPDATE pim_catalog_group_type SET is_variant = 0'),
             $destinationPim
         )->shouldBeCalled();
 

--- a/tests/spec/Domain/MigrationStep/s140_ProductMigration/ProductMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s140_ProductMigration/ProductMigratorSpec.php
@@ -42,8 +42,6 @@ class ProductMigratorSpec extends ObjectBehavior
         $productAssociationMigrator
     )
     {
-        $destinationPim->getDatabaseName()->willReturn('destination_database');
-
         $productAssociationMigrator->migrate($sourcePim, $destinationPim)->shouldBeCalled();
 
         $products = $this->getSourceProducts();
@@ -83,11 +81,11 @@ class ProductMigratorSpec extends ObjectBehavior
         ]);
 
         $console->execute(new MySqlExecuteCommand(
-            'UPDATE destination_database.pim_catalog_product SET created = "2017-09-01 12:45:41" WHERE identifier = "simple_product"'
+            'UPDATE pim_catalog_product SET created = "2017-09-01 12:45:41" WHERE identifier = "simple_product"'
         ), $destinationPim)->shouldBeCalled();
 
         $console->execute(new MySqlExecuteCommand(
-            'UPDATE destination_database.pim_catalog_product SET created = "2017-09-01 12:48:56" WHERE identifier = "product_with_associations"'
+            'UPDATE pim_catalog_product SET created = "2017-09-01 12:48:56" WHERE identifier = "product_with_associations"'
         ), $destinationPim)->shouldBeCalled();
 
         $secondUpsertProducts = new UpsertListProductsCommand([
@@ -105,7 +103,7 @@ class ProductMigratorSpec extends ObjectBehavior
         $secondUpsertProductsResult->getOutput()->willReturn([['status_code' => 201]]);
 
         $console->execute(new MySqlExecuteCommand(
-            'UPDATE destination_database.pim_catalog_product SET created = "2017-09-01 12:49:21" WHERE identifier = "product_with_variant_group"'
+            'UPDATE pim_catalog_product SET created = "2017-09-01 12:49:21" WHERE identifier = "product_with_variant_group"'
         ), $destinationPim)->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);


### PR DESCRIPTION
The database name is used in MySQL queries without quoting them. It throw an error if the database name contain an illegal character (be instance : "my-database")

Writing the database name is useless because the queries are executing for an MySQL connection on a specific database. So the best solution is to remove the database name usages.
