### PR TITLE
Mig-69: PIM v2.0.1 compatibility

### DIFF
--- a/src/Domain/MigrationStep/s110_GroupMigration/GroupMigrator.php
+++ b/src/Domain/MigrationStep/s110_GroupMigration/GroupMigrator.php
@@ -43,6 +43,10 @@ class GroupMigrator implements DataMigrator
             foreach ($this->groupMigrators as $groupMigrator) {
                 $groupMigrator->migrate($sourcePim, $destinationPim);
             }
+
+            $this->chainedConsole->execute(
+                new MySqlExecuteCommand('ALTER TABLE pim_catalog_group_type DROP COLUMN is_variant'), $destinationPim
+            );
         } catch (\Exception $exception) {
             throw new GroupMigrationException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Domain/MigrationStep/s110_GroupMigration/GroupMigrator.php
+++ b/src/Domain/MigrationStep/s110_GroupMigration/GroupMigrator.php
@@ -43,10 +43,6 @@ class GroupMigrator implements DataMigrator
             foreach ($this->groupMigrators as $groupMigrator) {
                 $groupMigrator->migrate($sourcePim, $destinationPim);
             }
-
-            $this->chainedConsole->execute(
-                new MySqlExecuteCommand('UPDATE pim_catalog_group_type SET is_variant = 0'), $destinationPim
-            );
         } catch (\Exception $exception) {
             throw new GroupMigrationException($exception->getMessage(), $exception->getCode(), $exception);
         }

--- a/src/Domain/MigrationStep/s120_ExtraDataMigration/ExtraDataMigrator.php
+++ b/src/Domain/MigrationStep/s120_ExtraDataMigration/ExtraDataMigrator.php
@@ -55,7 +55,6 @@ class ExtraDataMigrator implements DataMigrator
 
     protected function getSourcePimStandardTables(): array
     {
-        //TODO add EE tables
         return [
             'acl_classes',
             'acl_entries',

--- a/src/Infrastructure/Common/config/services.yml
+++ b/src/Infrastructure/Common/config/services.yml
@@ -412,12 +412,6 @@ services:
         $supportedTableName: 'pim_catalog_group_translation'
       tags: ['transporteo.group_migrator']
 
-  Akeneo\PimMigration\Domain\MigrationStep\s110_GroupMigration\GroupAttribute:
-      class: 'Akeneo\PimMigration\Domain\DataMigration\SimpleDataMigrator'
-      arguments:
-        $supportedTableName: 'pim_catalog_group_attribute'
-      tags: ['transporteo.group_migrator']
-
 ### EXTRA DATA MIGRATOR
 
   Akeneo\PimMigration\Domain\MigrationStep\s120_ExtraDataMigration\ExtraDataMigrator: ~

--- a/tests/spec/Domain/MigrationStep/s110_GroupMigration/GroupMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s110_GroupMigration/GroupMigratorSpec.php
@@ -44,7 +44,7 @@ class GroupMigratorSpec extends ObjectBehavior
         $groupMigratorTwo->migrate($sourcePim, $destinationPim)->shouldBeCalled();
 
         $chainedConsole->execute(
-            new MySqlExecuteCommand('UPDATE pim_catalog_group_type SET is_variant = 0'),
+            new MySqlExecuteCommand('ALTER TABLE pim_catalog_group_type DROP COLUMN is_variant'),
             $destinationPim
         )->shouldBeCalled();
 


### PR DESCRIPTION
Since v2.0.1 the table pim_catalog_group_attribute and the column pim_catalog_group_type.is_variant no longer exists in MySQL database.