### PR TITLE
Mig-70: Don't migrate products related to an invalid IVB

### DIFF
--- a/src/Domain/Command/Api/DeleteProductCommand.php
+++ b/src/Domain/Command/Api/DeleteProductCommand.php
@@ -24,7 +24,7 @@ class DeleteProductCommand implements ApiCommand
 
     public function getCommand(): string
     {
-        return self::class;
+        return 'Delete product '.$this->productCode;
     }
 
     public function getProductCode(): string

--- a/src/Domain/Command/Api/GetFamilyCommand.php
+++ b/src/Domain/Command/Api/GetFamilyCommand.php
@@ -24,7 +24,7 @@ class GetFamilyCommand implements ApiCommand
 
     public function getCommand(): string
     {
-        return self::class;
+        return 'Get family '.$this->familyCode;
     }
 
     public function getFamilyCode(): string

--- a/src/Domain/Command/Api/ListAllProductsCommand.php
+++ b/src/Domain/Command/Api/ListAllProductsCommand.php
@@ -24,7 +24,7 @@ class ListAllProductsCommand implements ApiCommand
 
     public function getCommand(): string
     {
-        return self::class;
+        return 'List all products';
     }
 
     public function getPageSize(): int

--- a/src/Domain/Command/Api/UpdateFamilyCommand.php
+++ b/src/Domain/Command/Api/UpdateFamilyCommand.php
@@ -24,7 +24,7 @@ class UpdateFamilyCommand implements ApiCommand
 
     public function getCommand(): string
     {
-        return self::class;
+        return 'Update family '.$this->getFamilyCode();
     }
 
     public function getFamily(): array

--- a/src/Domain/Command/Api/UpsertListProductsCommand.php
+++ b/src/Domain/Command/Api/UpsertListProductsCommand.php
@@ -24,7 +24,7 @@ class UpsertListProductsCommand implements ApiCommand
 
     public function getCommand(): string
     {
-        return self::class;
+        return 'Upsert products';
     }
 
     public function getProducts(): array

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationCleaner.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationCleaner.php
@@ -112,6 +112,11 @@ class InnerVariationCleaner
 
     private function deleteProduct(string $productCode, Pim $pim): void
     {
+        /**
+         * TODO: Do a SQL query when the console command "akeneo:elasticsearch:reset-indexes" can be used.
+         * The problem is that this command ask a confirmation.
+         * This command is available since the version 2.0.2 so we have to ensure that it's the minimal version of the destination PIM.
+         */
         $command = new DeleteProductCommand($productCode);
 
         try {

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationCleaner.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationCleaner.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration;
 
+use Akeneo\PimMigration\Domain\Command\Api\DeleteProductCommand;
 use Akeneo\PimMigration\Domain\Command\ChainedConsole;
 use Akeneo\PimMigration\Domain\Command\MySqlExecuteCommand;
+use Akeneo\PimMigration\Domain\Pim\DestinationPim;
 use Akeneo\PimMigration\Domain\Pim\Pim;
 use Psr\Log\LoggerInterface;
 
 /**
- * Cleans the InnerVariationType migration.
- *  - Deletes the deprecated families
- *  - Drops the IVB MySQL tables.
+ * Cleaning for the InnerVariationType migration.
  *
  * @author    Laurent Petard <laurent.petard@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -25,19 +25,52 @@ class InnerVariationCleaner
     /** @var LoggerInterface */
     private $logger;
 
-    public function __construct(ChainedConsole $console, LoggerInterface $logger)
+    /** @var InnerVariationRetriever */
+    private $innerVariationRetriever;
+
+    public function __construct(ChainedConsole $console, InnerVariationRetriever $innerVariationRetriever, LoggerInterface $logger)
     {
         $this->console = $console;
+        $this->innerVariationRetriever = $innerVariationRetriever;
         $this->logger = $logger;
     }
 
-    public function cleanInnerVariationTypes(array $innerVariationTypes, Pim $pim)
+    /**
+     * Cleans the InnerVariationType data in the destination PIM.
+     *  - Deletes the deprecated families
+     *  - Drops the IVB MySQL tables.
+     */
+    public function cleanInnerVariationTypes(array $innerVariationTypes, DestinationPim $pim): void
     {
         // Drop the tables before deleting families to avoid constraint issues.
         $this->dropInnerVariationTables($pim);
 
         foreach ($innerVariationTypes as $innerVariationType) {
             $this->deleteInnerVariationFamily($innerVariationType, $pim);
+        }
+    }
+
+    /**
+     * Deletes the products of the invalid InnerVariationType that could not been migrated.
+     */
+    public function deleteInvalidInnerVariationTypesProducts(array $invalidInnerVariationTypes, DestinationPim $pim): void
+    {
+        foreach ($invalidInnerVariationTypes as $invalidInnerVariationType) {
+            $innerVariationFamily = $this->innerVariationRetriever->retrieveInnerVariationFamily($invalidInnerVariationType, $pim);
+            $parentFamilies = $this->innerVariationRetriever->retrieveParentFamilies($invalidInnerVariationType, $pim);
+
+            foreach ($parentFamilies as $family) {
+                $products = $this->innerVariationRetriever->retrievesFamilyProductsHavingVariants($family->getId(), $innerVariationFamily->getId(), $pim);
+
+                foreach ($products as $product) {
+                    $this->deleteProduct($product['identifier'], $pim);
+                }
+            }
+        }
+
+        $productsVariants = $this->innerVariationRetriever->retrieveNotMigratedProductVariants($pim);
+        foreach ($productsVariants as $productsVariant) {
+            $this->deleteProduct($productsVariant['identifier'], $pim);
         }
     }
 
@@ -71,6 +104,19 @@ class InnerVariationCleaner
             $this->console->execute($dropMainTableCommand, $pim);
         } catch (\Exception $exception) {
             $this->logger->warning('Unable to drop all the InnerVariationType tables : '.$exception->getMessage());
+        }
+    }
+
+    private function deleteProduct(string $productCode, Pim $pim): void
+    {
+        $command = new DeleteProductCommand($productCode);
+
+        try {
+            $this->console->execute($command, $pim);
+        } catch (\Exception $exception) {
+            $this->logger->warning(sprintf(
+                'Unable to delete the product %s : %s', $productCode, $exception->getMessage()
+            ));
         }
     }
 }

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationCleaner.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationCleaner.php
@@ -39,6 +39,7 @@ class InnerVariationCleaner
      * Cleans the InnerVariationType data in the destination PIM.
      *  - Deletes the deprecated families
      *  - Drops the IVB MySQL tables.
+     *  - Delete the attribute "variation_parent_product".
      */
     public function cleanInnerVariationTypes(array $innerVariationTypes, DestinationPim $pim): void
     {
@@ -48,6 +49,8 @@ class InnerVariationCleaner
         foreach ($innerVariationTypes as $innerVariationType) {
             $this->deleteInnerVariationFamily($innerVariationType, $pim);
         }
+
+        $this->deleteInnerVariationAttribute($pim);
     }
 
     /**
@@ -116,6 +119,22 @@ class InnerVariationCleaner
         } catch (\Exception $exception) {
             $this->logger->warning(sprintf(
                 'Unable to delete the product %s : %s', $productCode, $exception->getMessage()
+            ));
+        }
+    }
+
+    /**
+     * Delete the attribute "variation_parent_product" specific to the IVB.
+     */
+    private function deleteInnerVariationAttribute(Pim $pim)
+    {
+        $deleteAttributeCommand = new MySqlExecuteCommand('DELETE FROM pim_catalog_attribute WHERE code = "variation_parent_product"');
+
+        try {
+            $this->console->execute($deleteAttributeCommand, $pim);
+        } catch (\Exception $exception) {
+            $this->logger->warning(sprintf(
+                'Unable to delete the attribute variation_parent_product : %s', $exception->getMessage()
             ));
         }
     }

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationRetriever.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationRetriever.php
@@ -165,7 +165,7 @@ class InnerVariationRetriever
     /**
      * Retrieves the data of a family variant from its parent families.
      */
-    public function retrieveFamilyVariant(Family $parentFamily, Family $innerVariationFamily, Pim $pim)
+    public function retrieveFamilyVariant(Family $parentFamily, Family $innerVariationFamily, Pim $pim): array
     {
         $sqlResult = $this->console->execute(new MySqlQueryCommand(sprintf(
             'SELECT id, family_id, code FROM pim_catalog_family_variant WHERE code = "%s"',
@@ -173,6 +173,18 @@ class InnerVariationRetriever
         )), $pim)->getOutput();
 
         return empty($sqlResult) ? [] : $sqlResult[0];
+    }
+
+    /**
+     * Retrieves the products variants that have not been migrated.
+     * The simplest way to do it is to find all the product that still have the attribute "variation_parent_product".
+     */
+    public function retrieveNotMigratedProductVariants(Pim $pim): array
+    {
+        return $this->console->execute(new MySqlQueryCommand(
+            "SELECT identifier FROM pim_catalog_product	
+             WHERE JSON_CONTAINS_PATH(raw_values, 'one', '$.variation_parent_product')"
+        ), $pim)->getOutput();
     }
 
     /**

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InvalidInnerVariationTypeException.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InvalidInnerVariationTypeException.php
@@ -17,7 +17,9 @@ class InvalidInnerVariationTypeException extends MigrationStepException
     public function __construct()
     {
         parent::__construct(
-            'Not all the inner variation types could be migrated. Their products have not been migrated either. See the file "var/logs/error.log" for more details.'
+            "Some inner variation types can't be automatically migrated. Related products have not been migrated yet."
+            .PHP_EOL."Your catalog structure should be rework, according to the catalog modeling introduced in v2.0 (Authorized axes are attributes of type 'Simple select', 'Reference data simple select', 'Metric', 'Boolean' and maximum 5 attributes per variant level)"
+            .PHP_EOL."See the file 'var/logs/error.log' for more details."
         );
     }
 }

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InvalidInnerVariationTypeException.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InvalidInnerVariationTypeException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration;
+
+use Akeneo\PimMigration\Domain\MigrationStep\MigrationStepException;
+
+/**
+ * Exception thrown when one or many inner variation types are invalid.
+ *
+ * @author    Laurent Petard <laurent.petard@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ */
+class InvalidInnerVariationTypeException extends MigrationStepException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Not all the inner variation types could be migrated. Their products have not been migrated either. See the file "var/logs/error.log" for more details.'
+        );
+    }
+}

--- a/src/Domain/PrinterAndAsker.php
+++ b/src/Domain/PrinterAndAsker.php
@@ -23,4 +23,6 @@ interface PrinterAndAsker
     public function note(string $message): void;
 
     public function printMessage(string $message): void;
+
+    public function warning(string $message): void;
 }

--- a/src/Infrastructure/MigrationStep/S150FromDestinationPimProductMigratedToDestinationPimProductVariationMigrated.php
+++ b/src/Infrastructure/MigrationStep/S150FromDestinationPimProductMigratedToDestinationPimProductVariationMigrated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\PimMigration\Infrastructure\MigrationStep;
 
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariationTypeMigrator;
+use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InvalidInnerVariationTypeException;
 use Akeneo\PimMigration\Infrastructure\TransporteoStateMachine;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -44,7 +45,11 @@ class S150FromDestinationPimProductMigratedToDestinationPimProductVariationMigra
 
         $this->printerAndAsker->printMessage($this->translator->trans('from_destination_pim_product_migrated_to_destination_pim_product_variation_migrated.message'));
 
-        $this->innerVariationTypeMigrator->migrate($stateMachine->getSourcePim(), $stateMachine->getDestinationPim());
+        try {
+            $this->innerVariationTypeMigrator->migrate($stateMachine->getSourcePim(), $stateMachine->getDestinationPim());
+        } catch (InvalidInnerVariationTypeException $exception) {
+            $this->printerAndAsker->warning($exception->getMessage());
+        }
 
         $this->logExit(__FUNCTION__);
     }

--- a/src/Infrastructure/UserInterface/Cli/ConsolePrinterAndAsker.php
+++ b/src/Infrastructure/UserInterface/Cli/ConsolePrinterAndAsker.php
@@ -72,4 +72,9 @@ class ConsolePrinterAndAsker implements PrinterAndAsker
     {
         $this->io->writeln($message);
     }
+
+    public function warning(string $message): void
+    {
+        $this->io->warning($message);
+    }
 }

--- a/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationTypeMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationTypeMigratorSpec.php
@@ -10,6 +10,7 @@ use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Inne
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariationRetriever;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariationType;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariationTypeMigrator;
+use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InvalidInnerVariationTypeException;
 use Akeneo\PimMigration\Domain\Pim\DestinationPim;
 use Akeneo\PimMigration\Domain\Pim\SourcePim;
 use PhpSpec\ObjectBehavior;
@@ -75,6 +76,7 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationFamilyMigrator->migrate($secondInnerVariationType, $destinationPim)->shouldBeCalled();
         $innerVariationProductMigrator->migrate($secondInnerVariationType, $destinationPim)->shouldBeCalled();
 
+        $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([], $destinationPim)->shouldBeCalled();
         $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $secondInnerVariationType], $destinationPim)->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);
@@ -120,9 +122,10 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationFamilyMigrator->migrate($invalidInnerVariationType, $destinationPim)->shouldNotBeCalled();
         $innerVariationProductMigrator->migrate($invalidInnerVariationType, $destinationPim)->shouldNotBeCalled();
 
-        $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType], $destinationPim)->shouldBeCalled();
+        $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([$invalidInnerVariationType], $destinationPim)->shouldBeCalled();
+        $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $invalidInnerVariationType], $destinationPim)->shouldBeCalled();
 
-        $this->migrate($sourcePim, $destinationPim);
+        $this->shouldThrow(new InvalidInnerVariationTypeException())->during('migrate', [$sourcePim, $destinationPim]);
     }
 
     public function it_does_not_migrate_ivt_having_an_invalid_axes(
@@ -160,9 +163,10 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationFamilyMigrator->migrate($invalidInnerVariationType, $destinationPim)->shouldNotBeCalled();
         $innerVariationProductMigrator->migrate($invalidInnerVariationType, $destinationPim)->shouldNotBeCalled();
 
-        $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType], $destinationPim)->shouldBeCalled();
+        $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([$invalidInnerVariationType], $destinationPim)->shouldBeCalled();
+        $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $invalidInnerVariationType], $destinationPim)->shouldBeCalled();
 
-        $this->migrate($sourcePim, $destinationPim);
+        $this->shouldThrow(new InvalidInnerVariationTypeException())->during('migrate', [$sourcePim, $destinationPim]);
     }
 
     public function it_continues_to_migrate_if_an_exception_is_thrown(
@@ -197,7 +201,8 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationFamilyMigrator->migrate($secondInnerVariationType, $destinationPim)->shouldBeCalled();
         $innerVariationProductMigrator->migrate($secondInnerVariationType, $destinationPim)->shouldBeCalled();
 
-        $innerVariationCleaner->cleanInnerVariationTypes([$secondInnerVariationType], $destinationPim)->shouldBeCalled();
+        $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([], $destinationPim)->shouldBeCalled();
+        $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $secondInnerVariationType], $destinationPim)->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);
     }

--- a/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationTypeMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariationTypeMigratorSpec.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace spec\Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration;
 
+use Akeneo\PimMigration\Domain\Command\ChainedConsole;
+use Akeneo\PimMigration\Domain\Command\SymfonyCommand;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariationCleaner;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariationFamilyMigrator;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariationProductMigrator;
@@ -23,6 +25,7 @@ use Psr\Log\LoggerInterface;
 class InnerVariationTypeMigratorSpec extends ObjectBehavior
 {
     public function let(
+        ChainedConsole $console,
         InnerVariationRetriever $innerVariationRetriever,
         InnerVariationFamilyMigrator $innerVariationFamilyMigrator,
         InnerVariationProductMigrator $innerVariationProductMigrator,
@@ -30,7 +33,7 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         LoggerInterface $logger
     )
     {
-        $this->beConstructedWith($innerVariationRetriever, $innerVariationFamilyMigrator, $innerVariationProductMigrator, $innerVariationCleaner, $logger);
+        $this->beConstructedWith($console, $innerVariationRetriever, $innerVariationFamilyMigrator, $innerVariationProductMigrator, $innerVariationCleaner, $logger);
     }
 
     public function it_is_initializable()
@@ -47,6 +50,7 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
     }
 
     public function it_successfully_migrates_inner_variation_types(
+        $console,
         $innerVariationRetriever,
         $innerVariationFamilyMigrator,
         $innerVariationProductMigrator,
@@ -79,10 +83,14 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([], $destinationPim)->shouldBeCalled();
         $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $secondInnerVariationType], $destinationPim)->shouldBeCalled();
 
+        $console->execute(new SymfonyCommand('pim:product:index --all'), $destinationPim)->shouldBeCalled();
+        $console->execute(new SymfonyCommand('pim:product-model:index --all'), $destinationPim)->shouldBeCalled();
+
         $this->migrate($sourcePim, $destinationPim);
     }
 
     public function it_does_not_migrate_ivt_having_more_than_five_axes(
+        $console,
         $innerVariationRetriever,
         $innerVariationFamilyMigrator,
         $innerVariationProductMigrator,
@@ -125,10 +133,14 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([$invalidInnerVariationType], $destinationPim)->shouldBeCalled();
         $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $invalidInnerVariationType], $destinationPim)->shouldBeCalled();
 
+        $console->execute(new SymfonyCommand('pim:product:index --all'), $destinationPim)->shouldBeCalled();
+        $console->execute(new SymfonyCommand('pim:product-model:index --all'), $destinationPim)->shouldBeCalled();
+
         $this->shouldThrow(new InvalidInnerVariationTypeException())->during('migrate', [$sourcePim, $destinationPim]);
     }
 
     public function it_does_not_migrate_ivt_having_an_invalid_axes(
+        $console,
         $innerVariationRetriever,
         $innerVariationFamilyMigrator,
         $innerVariationProductMigrator,
@@ -166,10 +178,14 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([$invalidInnerVariationType], $destinationPim)->shouldBeCalled();
         $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $invalidInnerVariationType], $destinationPim)->shouldBeCalled();
 
+        $console->execute(new SymfonyCommand('pim:product:index --all'), $destinationPim)->shouldBeCalled();
+        $console->execute(new SymfonyCommand('pim:product-model:index --all'), $destinationPim)->shouldBeCalled();
+
         $this->shouldThrow(new InvalidInnerVariationTypeException())->during('migrate', [$sourcePim, $destinationPim]);
     }
 
     public function it_continues_to_migrate_if_an_exception_is_thrown(
+        $console,
         $innerVariationRetriever,
         $innerVariationFamilyMigrator,
         $innerVariationProductMigrator,
@@ -203,6 +219,9 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
 
         $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([], $destinationPim)->shouldBeCalled();
         $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $secondInnerVariationType], $destinationPim)->shouldBeCalled();
+
+        $console->execute(new SymfonyCommand('pim:product:index --all'), $destinationPim)->shouldBeCalled();
+        $console->execute(new SymfonyCommand('pim:product-model:index --all'), $destinationPim)->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);
     }


### PR DESCRIPTION
Until it's possible to transform "simple" products into models and variants from the UI, the products of invalid inner variation types will not be migrated. To do that they have to be deleted. This modification is temporary.