### PR TITLE
Mig-77: Keep the internal jobs in destination PIM

### DIFF
--- a/src/Infrastructure/Common/messages.en.yml
+++ b/src/Infrastructure/Common/messages.en.yml
@@ -61,6 +61,8 @@ from_destination_pim_downloaded_to_destination_pim_installed:
     base_uri:
       question: "What is the base URI to request the API of the destination PIM?"
       error_message: "You should provide a valid URI without parameters."
+  on_local_destination_pim_system_requirements_installation:
+      message: "Preparing destination PIM database..."
 from_destination_pim_requirements_checked_to_destination_pim_files_database_migrated:
   message: "Migrating files data..."
 from_destination_pim_files_migrated_to_destination_pim_structure_migrated:

--- a/src/Infrastructure/Common/messages.en.yml
+++ b/src/Infrastructure/Common/messages.en.yml
@@ -62,7 +62,7 @@ from_destination_pim_downloaded_to_destination_pim_installed:
       question: "What is the base URI to request the API of the destination PIM?"
       error_message: "You should provide a valid URI without parameters."
   on_local_destination_pim_system_requirements_installation:
-      message: "Preparing destination PIM database..."
+      message: "Destination PIM database initialization..."
 from_destination_pim_requirements_checked_to_destination_pim_files_database_migrated:
   message: "Migrating files data..."
 from_destination_pim_files_migrated_to_destination_pim_structure_migrated:

--- a/src/Infrastructure/DestinationPimInstallation/BasicDestinationPimSystemRequirementsInstaller.php
+++ b/src/Infrastructure/DestinationPimInstallation/BasicDestinationPimSystemRequirementsInstaller.php
@@ -33,10 +33,6 @@ class BasicDestinationPimSystemRequirementsInstaller implements DestinationPimSy
         $this->fileSystemHelper = $fileSystemHelper;
     }
 
-    /**
-     * Drop and re-install the database with the minimum of fixtures.
-     * Using the fixtures "PimInstallerBundle:minimal" allows to have the internal jobs in the database (they don't exist in 1.7).
-     */
     public function install(DestinationPim $pim): void
     {
         $this->updatePimParameterInstallerDataToMinimal($pim);

--- a/src/Infrastructure/MigrationStep/S050FromDestinationPimDownloadedToDestinationPimInstalled.php
+++ b/src/Infrastructure/MigrationStep/S050FromDestinationPimDownloadedToDestinationPimInstalled.php
@@ -220,6 +220,10 @@ class S050FromDestinationPimDownloadedToDestinationPimInstalled extends Abstract
         /** @var TransporteoStateMachine $stateMachine */
         $stateMachine = $event->getSubject();
 
+        $this->printerAndAsker->printMessage($this->translator->trans(
+            'from_destination_pim_downloaded_to_destination_pim_installed.on_local_destination_pim_system_requirements_installation.message'
+        ));
+
         try {
             $this->destinationPimSystemRequirementsInstallerHelper->install($stateMachine->getDestinationPim());
         } catch (DestinationPimSystemRequirementsNotBootable $exception) {

--- a/tests/integration/DatabaseSetupedTestCase.php
+++ b/tests/integration/DatabaseSetupedTestCase.php
@@ -44,8 +44,8 @@ abstract class DatabaseSetupedTestCase extends ConfiguredTestCase
 
         $apiParameters = new PimApiParameters('', '', '', '', '');
 
-        $this->sourcePim = new SourcePim($sourcePimConfig['database_host'], $sourcePimConfig['database_port'], $sourcePimConfig['database_name'], $sourcePimConfig['database_user'], $sourcePimConfig['database_password'], null, null, false, null, false, $sourcePimConfig['absolute_path'], new Localhost(), $apiParameters);
-        $this->destinationPim = new DestinationPim($destinationPimConfig['database_host'], $destinationPimConfig['database_port'], $destinationPimConfig['database_name'], $destinationPimConfig['database_user'], $destinationPimConfig['database_password'], false, null, $destinationPimConfig['absolute_path'], new Localhost(), $apiParameters);
+        $this->sourcePim = new SourcePim($sourcePimConfig['database_host'], $sourcePimConfig['database_port'], $sourcePimConfig['database_name'], $sourcePimConfig['database_user'], $sourcePimConfig['database_password'], null, null, false, false, $sourcePimConfig['absolute_path'], new Localhost(), $apiParameters);
+        $this->destinationPim = new DestinationPim($destinationPimConfig['database_host'], $destinationPimConfig['database_port'], $destinationPimConfig['database_name'], $destinationPimConfig['database_user'], $destinationPimConfig['database_password'], false, $destinationPimConfig['absolute_path'], new Localhost(), $apiParameters);
 
         $connection = $this->getConnection($this->destinationPim, false);
         $connection->exec('DROP DATABASE IF EXISTS akeneo_pim_two_for_test');

--- a/tests/integration/Infrastructure/DatabaseServices/DumpTableMigratorIntegration.php
+++ b/tests/integration/Infrastructure/DatabaseServices/DumpTableMigratorIntegration.php
@@ -29,8 +29,8 @@ class DumpTableMigratorIntegration extends DatabaseSetupedTestCase
 
         $apiParameters = new PimApiParameters('', '', '', '', '');
 
-        $sourcePim = new SourcePim('localhost', 3310, 'akeneo_pim', 'akeneo_pim', 'akeneo_pim', null, null, false, null, false, '/a-path', new Localhost(), $apiParameters);
-        $destinationPim = new DestinationPim('localhost', 3311, 'akeneo_pim', 'akeneo_pim', 'akeneo_pim', false, null, '/a-path', new Localhost(), $apiParameters);
+        $sourcePim = new SourcePim('localhost', 3310, 'akeneo_pim', 'akeneo_pim', 'akeneo_pim', null, null, false, false, '/a-path', new Localhost(), $apiParameters);
+        $destinationPim = new DestinationPim('localhost', 3311, 'akeneo_pim', 'akeneo_pim', 'akeneo_pim', false, '/a-path', new Localhost(), $apiParameters);
 
         $fileFetcherRegistry = new FileFetcherRegistry();
         $fileFetcherRegistry->addFileFetcher(new LocalFileFetcher(new FileSystemHelper()));


### PR DESCRIPTION
Since PIM 2.0 there are some "internal" jobs that have been added. There are created at the installation and must remain in the database. The problem is that the jobs are migrated by a MySQL dump that erase this internal jobs.

To keep this internal jobs, they have first to be installed. To do that I re-worked the destination PIM installation to execute the command "pim:installer:db" with the catalog fixtures "minimal". Then at the jobs migration step, the table "akeneo_batch_job_instance" is copied to keep the internal jobs, and they  are re-inserted after the SQL dump.