### PR TITLE
MIG-91: Missing variant group combination validation

### DIFF
--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/VariantGroup/VariantGroupValidator.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/VariantGroup/VariantGroupValidator.php
@@ -61,7 +61,7 @@ class VariantGroupValidator
      */
     public function isVariantGroupCombinationValid(VariantGroupCombination $variantGroupCombination, Pim $pim): bool
     {
-        $familyAttributes =$variantGroupCombination->getFamily()->getAttributes();
+        $familyAttributes = $variantGroupCombination->getFamily()->getAttributes();
 
         $previousGroupAttributes = null;
         foreach ($variantGroupCombination->getGroups() as $group) {
@@ -93,6 +93,19 @@ class VariantGroupValidator
                 $variantGroupCombination->getFamily()->getCode(),
                 implode(', ', $variantGroupCombination->getAxes()),
                 implode(', ', $differencesWithTheFamilyAttributes)
+            ));
+
+            return false;
+        }
+
+        $axesNotInFamilyAttributes = array_diff($variantGroupCombination->getAxes(), $variantGroupCombination->getFamily()->getAttributes());
+
+        if (!empty($axesNotInFamilyAttributes)) {
+            $this->logger->warning(sprintf(
+                "Unable to migrate the variations for the family %s and axis %s, because all the following axes of the variant groups don't belong to the family : %s",
+                $variantGroupCombination->getFamily()->getCode(),
+                implode(', ', $variantGroupCombination->getAxes()),
+                implode(', ', $axesNotInFamilyAttributes)
             ));
 
             return false;

--- a/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/VariantGroup/VariantGroupValidatorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/VariantGroup/VariantGroupValidatorSpec.php
@@ -104,4 +104,23 @@ class VariantGroupValidatorSpec extends ObjectBehavior
 
         $this->isVariantGroupCombinationValid($variantGroupCombination, $pim)->shouldReturn(false);
     }
+
+    public function it_invalidates_a_variant_group_combination_if_an_axis_does_not_belong_to_the_family(
+        $variantGroupRepository,
+        $logger,
+        DestinationPim $pim
+    )
+    {
+        $family = new Family(11, 'family_1', ['attributes' => ['att_1', 'att_2', 'axis_2']]);
+        $variantGroupCombination = new VariantGroupCombination($family,['axis_1', 'axis_2', 'axis_3'], ['group_1', 'group_2'], []);
+
+        $variantGroupRepository->retrieveGroupAttributes('group_1', $pim)->willReturn(['att_1']);
+        $variantGroupRepository->retrieveGroupAttributes('group_2', $pim)->willReturn(['att_1']);
+
+        $logger->warning(
+            "Unable to migrate the variations for the family family_1 and axis axis_1, axis_2, because all the following axes of the variant groups don't belong to the family : axis_1, axis_3"
+        )->shouldBeCalled();
+
+        $this->isVariantGroupCombinationValid($variantGroupCombination, $pim)->shouldReturn(false);
+    }
 }


### PR DESCRIPTION
A validation rule has been forgotten for the variant group migration. If, for a given combination of family/variant-group an axis is not an attribute of the family, then this variant groups must not be migrated.