### PR TITLE
MIG-94: do not delete products of invalid inner variation types

### DIFF
--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationCleaner.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationCleaner.php
@@ -63,30 +63,6 @@ class InnerVariationCleaner
         $this->deleteInnerVariationAttribute($pim);
     }
 
-    /**
-     * Deletes the products of the invalid InnerVariationType that could not been migrated.
-     */
-    public function deleteInvalidInnerVariationTypesProducts(array $invalidInnerVariationTypes, DestinationPim $pim): void
-    {
-        foreach ($invalidInnerVariationTypes as $invalidInnerVariationType) {
-            $innerVariationFamily = $invalidInnerVariationType->getVariationFamily();
-            $parentFamilies = $this->innerVariationTypeRepository->getParentFamiliesHavingVariantProducts($invalidInnerVariationType, $pim);
-
-            foreach ($parentFamilies as $family) {
-                $products = $this->productRepository->findAllHavingVariantsForIvb($family->getId(), $innerVariationFamily->getId(), $pim);
-
-                foreach ($products as $product) {
-                    $this->productRepository->delete($product->getIdentifier(), $pim);
-                }
-            }
-        }
-
-        $productsVariants = $this->productRepository->findAllNotMigratedProductVariants($pim);
-        foreach ($productsVariants as $productsVariant) {
-            $this->productRepository->delete($productsVariant->getIdentifier(), $pim);
-        }
-    }
-
     private function deleteInnerVariationFamily(InnerVariationType $innerVariationType, Pim $pim): void
     {
         $deleteFamilyCommand = new MySqlExecuteCommand('DELETE FROM pim_catalog_family WHERE id = '.$innerVariationType->getVariationFamilyId());

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationTypeMigrator.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationTypeMigrator.php
@@ -72,7 +72,6 @@ class InnerVariationTypeMigrator implements DataMigrator
             }
         }
 
-        $this->innerVariationCleaner->deleteInvalidInnerVariationTypesProducts($invalidInnerVariationTypes, $destinationPim);
         $this->innerVariationCleaner->cleanInnerVariationTypes($innerVariationTypes, $destinationPim);
 
         if (!empty($invalidInnerVariationTypes)) {

--- a/tests/spec/Domain/MigrationStep/s050_DestinationPimInstallation/DestinationPimVersionCheckerSpec.php
+++ b/tests/spec/Domain/MigrationStep/s050_DestinationPimInstallation/DestinationPimVersionCheckerSpec.php
@@ -67,7 +67,7 @@ class DestinationPimVersionCheckerSpec extends ObjectBehavior
         $commandResult->getOutput()->willReturn('| Version  | 2.0.2 ');
 
         $this->shouldThrow(new DestinationPimCheckConfigurationException(sprintf(
-            'The current version of your destination PIM 2.0.2 is not supported. The minimum supported version is %d.%d.%d',
+            'The current version of your destination PIM 2.0.2 is not supported. The minimum version of the destination PIM is %d.%d.%d',
             DestinationPimVersionChecker::EXACT_MAJOR_VERSION,
             DestinationPimVersionChecker::EXACT_MINOR_VERSION,
             DestinationPimVersionChecker::MINIMUM_PATCH_VERSION

--- a/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationTypeMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationTypeMigratorSpec.php
@@ -83,7 +83,6 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationFamilyMigrator->migrate($secondInnerVariationType, $destinationPim)->shouldBeCalled();
         $innerVariationProductMigrator->migrate($secondInnerVariationType, $destinationPim)->shouldBeCalled();
 
-        $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([], $destinationPim)->shouldBeCalled();
         $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $secondInnerVariationType], $destinationPim)->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);
@@ -129,7 +128,6 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationFamilyMigrator->migrate($invalidInnerVariationType, $destinationPim)->shouldNotBeCalled();
         $innerVariationProductMigrator->migrate($invalidInnerVariationType, $destinationPim)->shouldNotBeCalled();
 
-        $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([$invalidInnerVariationType], $destinationPim)->shouldBeCalled();
         $innerVariationCleaner->cleanInnerVariationTypes([$validInnerVariationType, $invalidInnerVariationType], $destinationPim)->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);
@@ -172,7 +170,6 @@ class InnerVariationTypeMigratorSpec extends ObjectBehavior
         $innerVariationFamilyMigrator->migrate($secondInnerVariationType, $destinationPim)->shouldBeCalled();
         $innerVariationProductMigrator->migrate($secondInnerVariationType, $destinationPim)->shouldBeCalled();
 
-        $innerVariationCleaner->deleteInvalidInnerVariationTypesProducts([], $destinationPim)->shouldBeCalled();
         $innerVariationCleaner->cleanInnerVariationTypes([$firstInnerVariationType, $secondInnerVariationType], $destinationPim)->shouldBeCalled();
 
         $this->migrate($sourcePim, $destinationPim);


### PR DESCRIPTION
Deleting the products of invalid inner variation types was temporary. Now that it's possible to transform a product into a product model, it's better to let this products as they are in the destination PIM