### PR TITLE
PIM-7114: Migration of products on IVB family

### DIFF
--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationFamilyMigrator.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationFamilyMigrator.php
@@ -9,6 +9,7 @@ use Akeneo\PimMigration\Domain\Command\ChainedConsole;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\Family;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\FamilyVariant;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\InnerVariationType;
+use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\FamilyRepository;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\FamilyVariantImporter;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\FamilyVariantRepository;
 use Akeneo\PimMigration\Domain\Pim\Pim;
@@ -39,24 +40,29 @@ class InnerVariationFamilyMigrator
     /** @var FamilyVariantRepository */
     private $familyVariantRepository;
 
+    /** @var FamilyRepository */
+    private $familyRepository;
+
     public function __construct(
         InnerVariationTypeRepository $innerVariationTypeRepository,
         FamilyVariantImporter $familyVariantImporter,
         ChainedConsole $console,
         LoggerInterface $logger,
-        FamilyVariantRepository $familyVariantRepository
+        FamilyVariantRepository $familyVariantRepository,
+        FamilyRepository $familyRepository
     ) {
         $this->innerVariationTypeRepository = $innerVariationTypeRepository;
         $this->familyVariantImporter = $familyVariantImporter;
         $this->logger = $logger;
         $this->console = $console;
         $this->familyVariantRepository = $familyVariantRepository;
+        $this->familyRepository = $familyRepository;
     }
 
     public function migrate(InnerVariationType $innerVariationType, Pim $pim): void
     {
         $innerVariationFamily = $innerVariationType->getVariationFamily();
-        $parentFamilies = $this->innerVariationTypeRepository->getParentFamiliesHavingVariantProducts($innerVariationType, $pim);
+        $parentFamilies = $this->familyRepository->findAllByInnerVariationType($innerVariationType, $pim);
 
         foreach ($parentFamilies as $parentFamily) {
             $this->migrateFamilyAttributes($parentFamily, $innerVariationFamily, $pim);

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationTypeRepository.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationTypeRepository.php
@@ -95,33 +95,6 @@ class InnerVariationTypeRepository
     }
 
     /**
-     * Retrieves parent families having variant products related to an InnerVariationType.
-     */
-    public function getParentFamiliesHavingVariantProducts(InnerVariationType $innerVariationType, Pim $pim): \Traversable
-    {
-        $parentFamiliesData = $this->console->execute(
-            new MySqlQueryCommand(sprintf(
-                'SELECT DISTINCT f.code, f.id
-                 FROM pim_inner_variation_inner_variation_type ivt
-                 INNER JOIN pim_inner_variation_inner_variation_type_family ivtf ON ivtf.inner_variation_type_id = ivt.id
-                 INNER JOIN pim_catalog_family f ON f.id = ivtf.family_id
-                 INNER JOIN pim_catalog_product product_model ON product_model.family_id = f.id
-                 WHERE ivt.id = %d
-                  AND EXISTS(
-                     SELECT * FROM pim_catalog_product AS product_variant
-                     WHERE product_variant.family_id = ivt.variation_family_id
-                     AND JSON_EXTRACT(product_variant.raw_values, \'$.variation_parent_product."<all_channels>"."<all_locales>"\') = product_model.identifier
-                 )',
-                 $innerVariationType->getId()
-        )), $pim
-        )->getOutput();
-
-        foreach ($parentFamiliesData as $parentFamilyData) {
-            yield $this->buildFamily((int) $parentFamilyData['id'], $parentFamilyData['code'], $pim);
-        }
-    }
-
-    /**
      * Retrieves the label of an InnerVariationType for a given locale.
      */
     public function getLabel(InnerVariationType $innerVariationType, string $locale, Pim $pim): string
@@ -177,16 +150,5 @@ class InnerVariationTypeRepository
             ),
             $pim
         )->getOutput();
-    }
-
-    /**
-     * Retrieves all the data of a family.
-     */
-    private function buildFamily(int $familyId, string $familyCode, Pim $pim): Family
-    {
-        $apiCommand = new GetFamilyCommand($familyCode);
-        $familyStandardData = $this->console->execute($apiCommand, $pim)->getOutput();
-
-        return new Family($familyId, $familyCode, $familyStandardData);
     }
 }

--- a/src/Domain/MigrationStep/s150_ProductVariationMigration/ProductRepository.php
+++ b/src/Domain/MigrationStep/s150_ProductVariationMigration/ProductRepository.php
@@ -8,6 +8,7 @@ use Akeneo\PimMigration\Domain\Command\Api\DeleteProductCommand;
 use Akeneo\PimMigration\Domain\Command\Api\GetProductCommand;
 use Akeneo\PimMigration\Domain\Command\ChainedConsole;
 use Akeneo\PimMigration\Domain\Command\MySqlQueryCommand;
+use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\Family;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\Product;
 use Akeneo\PimMigration\Domain\Pim\Pim;
 
@@ -41,15 +42,11 @@ class ProductRepository
         return $categories;
     }
 
-    public function findAllHavingVariantsForIvb(int $parentFamilyId, int $innerVariationFamilyId, Pim $pim): \Traversable
+    public function findAllByFamily(Family $family, Pim $pim): \Traversable
     {
         $sqlResults = $this->console->execute(new MySqlQueryCommand(sprintf(
-                'SELECT id, identifier FROM pim_catalog_product AS product_model
-            WHERE family_id = %d AND EXISTS(
-                SELECT * FROM pim_catalog_product AS product_variant
-                WHERE product_variant.family_id = %d
-                AND JSON_EXTRACT(product_variant.raw_values, \'$.variation_parent_product."<all_channels>"."<all_locales>"\') = product_model.identifier
-            );', $parentFamilyId, $innerVariationFamilyId)
+            'SELECT id, identifier FROM pim_catalog_product WHERE family_id = %d',
+            $family->getId())
         ), $pim)->getOutput();
 
         foreach ($sqlResults as $result) {

--- a/src/Infrastructure/Cli/LocalMySqlQueryExecutor.php
+++ b/src/Infrastructure/Cli/LocalMySqlQueryExecutor.php
@@ -38,7 +38,7 @@ class LocalMySqlQueryExecutor
     public function getConnection(Pim $pim): \PDO
     {
         $dsn = sprintf(
-            'mysql: host=%s;dbname=%s;port=%s',
+            'mysql:host=%s;dbname=%s;port=%s',
             $pim->getMysqlHost(),
             $pim->getDatabaseName(),
             strval($pim->getMysqlPort())

--- a/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationFamilyMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationFamilyMigratorSpec.php
@@ -9,6 +9,7 @@ use Akeneo\PimMigration\Domain\Command\ChainedConsole;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\Family;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\FamilyVariant;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\InnerVariationType;
+use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\FamilyRepository;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\FamilyVariantImporter;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\FamilyVariantRepository;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariation\InnerVariationFamilyMigrator;
@@ -28,7 +29,8 @@ class InnerVariationFamilyMigratorSpec extends ObjectBehavior
         FamilyVariantImporter $familyVariantImporter,
         ChainedConsole $console,
         LoggerInterface $logger,
-        FamilyVariantRepository $familyVariantRepository
+        FamilyVariantRepository $familyVariantRepository,
+        FamilyRepository $familyRepository
     )
     {
         $this->beConstructedWith(
@@ -36,7 +38,8 @@ class InnerVariationFamilyMigratorSpec extends ObjectBehavior
             $familyVariantImporter,
             $console,
             $logger,
-            $familyVariantRepository
+            $familyVariantRepository,
+            $familyRepository
         );
     }
 
@@ -47,6 +50,7 @@ class InnerVariationFamilyMigratorSpec extends ObjectBehavior
 
     function it_successfully_migrates_families(
         $innerVariationTypeRepository,
+        $familyRepository,
         InnerVariationType $innerVariationType,
         DestinationPim $pim,
         FamilyVariantRepository $familyVariantRepository,
@@ -93,7 +97,7 @@ class InnerVariationFamilyMigratorSpec extends ObjectBehavior
             ]
         ]);
 
-        $innerVariationTypeRepository->getParentFamiliesHavingVariantProducts($innerVariationType, $pim)->willReturn(new \ArrayObject([$firstParentFamily, $secondParentFamily]));
+        $familyRepository->findAllByInnerVariationType($innerVariationType, $pim)->willReturn(new \ArrayObject([$firstParentFamily, $secondParentFamily]));
 
         $console->execute(new UpdateFamilyCommand([
             'code' => 'first_parent_family',

--- a/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationProductMigratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s150_ProductVariationMigration/InnerVariation/InnerVariationProductMigratorSpec.php
@@ -9,9 +9,9 @@ use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Enti
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\InnerVariationType;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\Product;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\Entity\ProductModel;
+use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\FamilyRepository;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\FamilyVariantRepository;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariation\InnerVariationProductMigrator;
-use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariation\InnerVariationTypeRepository;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariation\ProductModelBuilder;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\InnerVariation\ProductVariantTransformer;
 use Akeneo\PimMigration\Domain\MigrationStep\s150_ProductVariationMigration\ProductModelRepository;
@@ -27,7 +27,7 @@ use Psr\Log\LoggerInterface;
 class InnerVariationProductMigratorSpec extends ObjectBehavior
 {
     function let(
-        InnerVariationTypeRepository $innerVariationTypeRepository,
+        FamilyRepository $familyRepository,
         LoggerInterface $logger,
         ProductRepository $productRepository,
         ProductModelBuilder $productModelBuilder,
@@ -37,7 +37,7 @@ class InnerVariationProductMigratorSpec extends ObjectBehavior
     )
     {
         $this->beConstructedWith(
-            $innerVariationTypeRepository,
+            $familyRepository,
             $logger,
             $productRepository,
             $productModelBuilder,
@@ -53,7 +53,7 @@ class InnerVariationProductMigratorSpec extends ObjectBehavior
     }
 
     function it_successfully_migrates_products(
-        $innerVariationTypeRepository,
+        $familyRepository,
         $productModelRepository,
         $familyVariantRepository,
         $productRepository,
@@ -67,14 +67,14 @@ class InnerVariationProductMigratorSpec extends ObjectBehavior
         $parentFamily = new Family(10, 'first_parent_family', []);
 
         $innerVariationType->getVariationFamily()->willReturn($innerVariationFamily);
-        $innerVariationTypeRepository->getParentFamiliesHavingVariantProducts($innerVariationType, $pim)->willReturn(new \ArrayObject([$parentFamily]));
+        $familyRepository->findAllByInnerVariationType($innerVariationType, $pim)->willReturn(new \ArrayObject([$parentFamily]));
 
         $familyVariant = new FamilyVariant(20, 'first_family_variant');
         $familyVariantRepository->findOneByCode('first_parent_family', $pim)->willReturn($familyVariant);
 
         $product1 = new Product(110, 'product_model_1', null, null, null);
 
-        $productRepository->findAllHavingVariantsForIvb(10, 1, $pim)->willReturn(new \ArrayObject([$product1]));
+        $productRepository->findAllByFamily($parentFamily, $pim)->willReturn(new \ArrayObject([$product1]));
 
         $productRepository->getCategoryCodes(110, $pim)->willReturn(['cat_1', 'cat_2']);
 


### PR DESCRIPTION
All the products of a family that is related to an inner variation type must be migrated as product models, even if they don't have any variants.

Currently, only the products having variants (via the IVB) are transformed in product models.

This doesn't affect the mixed variations with variant group and inner variation types.