### PR TITLE
Allow port in url for source and destination

### DIFF
--- a/src/Infrastructure/MigrationStep/S015FromSourcePimConfiguredToSourcePimApiConfigured.php
+++ b/src/Infrastructure/MigrationStep/S015FromSourcePimConfiguredToSourcePimApiConfigured.php
@@ -71,7 +71,7 @@ class S015FromSourcePimConfiguredToSourcePimApiConfigured extends AbstractStateM
         $validator = function ($answer) {
             // This URI validation regex is intentionally imperfect.
             // It's goal is only to avoid common mistakes like forgetting "http", or adding parameters from a copy/paste.
-            if (0 === preg_match('~^https?:\/\/[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\/?$~i', $answer)) {
+            if (0 === preg_match('~^https?:\/\/[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\/?(?:\:?\d{1,4})?$~i', $answer)) {
                 throw new \RuntimeException(
                     $this->translator->trans(
                         'from_source_pim_configured_to_source_pim_api_configured.on_source_pim_api_configuration.base_uri.error_message'

--- a/src/Infrastructure/MigrationStep/S015FromSourcePimConfiguredToSourcePimApiConfigured.php
+++ b/src/Infrastructure/MigrationStep/S015FromSourcePimConfiguredToSourcePimApiConfigured.php
@@ -71,7 +71,7 @@ class S015FromSourcePimConfiguredToSourcePimApiConfigured extends AbstractStateM
         $validator = function ($answer) {
             // This URI validation regex is intentionally imperfect.
             // It's goal is only to avoid common mistakes like forgetting "http", or adding parameters from a copy/paste.
-            if (0 === preg_match('~^https?:\/\/[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\/?(?:\:?\d{1,4})?$~i', $answer)) {
+            if (0 === preg_match('~^https?:\/\/[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\/?(?:\:\d{1,4})?$~i', $answer)) {
                 throw new \RuntimeException(
                     $this->translator->trans(
                         'from_source_pim_configured_to_source_pim_api_configured.on_source_pim_api_configuration.base_uri.error_message'

--- a/src/Infrastructure/MigrationStep/S050FromDestinationPimDownloadedToDestinationPimInstalled.php
+++ b/src/Infrastructure/MigrationStep/S050FromDestinationPimDownloadedToDestinationPimInstalled.php
@@ -168,7 +168,7 @@ class S050FromDestinationPimDownloadedToDestinationPimInstalled extends Abstract
                 function ($answer) {
                     // This URI validation regex is intentionally imperfect.
                     // It's goal is only to avoid common mistakes like forgetting "http", or adding parameters from a copy/paste.
-                    if (0 === preg_match('~^https?:\/\/[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\/?(?:\:?\d{1,4})?$~i', $answer)) {
+                    if (0 === preg_match('~^https?:\/\/[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\/?(?:\:\d{1,4})?$~i', $answer)) {
                         throw new \RuntimeException(
                             $this->translator->trans(
                                 'from_destination_pim_downloaded_to_destination_pim_installed.on_destination_pim_api_configuration.base_uri.error_message'

--- a/src/Infrastructure/MigrationStep/S050FromDestinationPimDownloadedToDestinationPimInstalled.php
+++ b/src/Infrastructure/MigrationStep/S050FromDestinationPimDownloadedToDestinationPimInstalled.php
@@ -168,7 +168,7 @@ class S050FromDestinationPimDownloadedToDestinationPimInstalled extends Abstract
                 function ($answer) {
                     // This URI validation regex is intentionally imperfect.
                     // It's goal is only to avoid common mistakes like forgetting "http", or adding parameters from a copy/paste.
-                    if (0 === preg_match('~^https?:\/\/[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\/?$~i', $answer)) {
+                    if (0 === preg_match('~^https?:\/\/[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\/?(?:\:?\d{1,4})?$~i', $answer)) {
                         throw new \RuntimeException(
                             $this->translator->trans(
                                 'from_destination_pim_downloaded_to_destination_pim_installed.on_destination_pim_api_configuration.base_uri.error_message'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
**Description**
Before : local server have to run on port 80, if a port is specified, it is NOT handle and ask for an URI running on port 80.
After : A port can be specified (as usual after `:`) [For both source and destination] , if not provided, then, the server is supposed to run on port 80.
<!--- (What does this Pull Request do? reference the related issue?) --->
FIX #70 : You can now add a port to the URI
The regexp has been modified to handle a port after the URI
**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | `-`
| Review and 2 GTM                  | `-`
| Micro Demo to the PO (Story only) | `-`

A migration with the two Pim 'Source' and 'Destination' running with built-in server has been successfully performed.