### PR TITLE
Fix issue #125: Potential exception on Reference Data migration

### DIFF
--- a/src/Domain/DataMigration/EntityMappingChecker.php
+++ b/src/Domain/DataMigration/EntityMappingChecker.php
@@ -32,6 +32,11 @@ class EntityMappingChecker
     public function check(Pim $pim, string $entityClassPath): void
     {
         try {
+            $this->chainedConsole->execute(
+              new SymfonyCommand('cache:clear', SymfonyCommand::PROD),
+              $pim
+            );
+
             $commandResult = $this->chainedConsole->execute(
                 new SymfonyCommand('doctrine:mapping:info', SymfonyCommand::PROD),
                 $pim

--- a/src/Domain/MigrationStep/s130_ReferenceDataMigration/ReferenceDataConfigurator.php
+++ b/src/Domain/MigrationStep/s130_ReferenceDataMigration/ReferenceDataConfigurator.php
@@ -30,7 +30,7 @@ class ReferenceDataConfigurator
         $this->logger = $logger;
     }
 
-    public function configure(array $referenceDataConfig, string $tableName, Pim $pim): string
+    public function configure(string $referenceDataName, array $referenceDataConfig, string $tableName, Pim $pim): string
     {
         $this->logger->debug('ReferenceDataConfigurator: Start configuring');
 
@@ -102,7 +102,7 @@ class ReferenceDataConfigurator
 
         $referenceDataConfig['class'] = $newClassPath;
 
-        $configFile['pim_reference_data'][] = $referenceDataConfig;
+        $configFile['pim_reference_data'][$referenceDataName] = $referenceDataConfig;
 
         $this->fileSystem->dumpYamlInFile($configFilePath, $configFile);
 

--- a/src/Domain/MigrationStep/s130_ReferenceDataMigration/ReferenceDataMigrator.php
+++ b/src/Domain/MigrationStep/s130_ReferenceDataMigration/ReferenceDataMigrator.php
@@ -86,9 +86,10 @@ class ReferenceDataMigrator implements DataMigrator
                 $referenceDataTableName = $this->entityTableNameFetcher->fetchTableName($sourcePim, $referenceData['class']);
                 $this->logger->debug(sprintf('ReferenceDataMigrator: Class %s is related to %s table_name', $referenceData['class'], $referenceDataTableName));
 
+                $referenceDataName = strtolower(substr($referenceData['class'], strrpos($referenceData['class'], '\\') + 1));
                 $destinationReferenceDataNamespace = $this
                     ->referenceDataConfigurator
-                    ->configure($referenceData, $referenceDataTableName, $destinationPim)
+                    ->configure($referenceDataName, $referenceData, $referenceDataTableName, $destinationPim)
                 ;
 
                 $this->entityMappingChecker->check($destinationPim, $destinationReferenceDataNamespace);

--- a/tests/spec/Domain/MigrationStep/s130_ReferenceDataMigration/ReferenceDataConfiguratorSpec.php
+++ b/tests/spec/Domain/MigrationStep/s130_ReferenceDataMigration/ReferenceDataConfiguratorSpec.php
@@ -164,7 +164,7 @@ class ReferenceDataConfiguratorSpec extends ObjectBehavior
 
         $configResult = [
             'pim_reference_data' => [
-                0 => [
+                'fabric' => [
                     'class' => 'Akeneo\Bundle\MigrationBundle\Entity\Fabric',
                     'type' => 'multi',
                 ]
@@ -179,7 +179,7 @@ class ReferenceDataConfiguratorSpec extends ObjectBehavior
 
         $fileSystem->dumpYamlInFile($configFilePath, $configResult)->shouldBeCalled();
 
-        $this->configure($fabric, 'acme_reference_data_fabric', $pim)->shouldReturn('Akeneo\Bundle\MigrationBundle\Entity\Fabric');
+        $this->configure('fabric', $fabric, 'acme_reference_data_fabric', $pim)->shouldReturn('Akeneo\Bundle\MigrationBundle\Entity\Fabric');
     }
 
     public function it_does_nothing_for_an_asset(Pim $pim)


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
Because Transporteo doesn't set named key on the "reference-data" table, the generated configuration for reference datas is invalid according to "bin/console pim:reference-data:check --env=prod" command: ""

Indeed, the reference-data config is generated as follow:

```
pim_reference_data:  
    assets:
        class: PimEnterprise\Component\ProductAsset\Model\Asset
        type: multi
    0:
        class: [fully qualified class name]
        type: [type]
```

While it should be:

```
pim_reference_data:
    assets:
        class: PimEnterprise\Component\ProductAsset\Model\Asset
        type: multi
    [entityMachineName]:
        class: [fully qualified class name]
        type: [type]
```

Resulting that the entities aren't configured properly and a _InvalidArgumentException_ with message "The entity [fully qualified class name] is not configured"

 Also sometimes the check using 'doctrine:mapping:info' command (on AntityMappingChecker class) doesn't list the newly injected (on the configuration) entity reference data, because of the cache and also make the migration fails with a _InvalidArgumentException_ "The entity [fully qualified class name] is not configured"

To avoid that case I added a call to cache:clear before doctrine:mapping:info check, so that the mapping info is always up to date when the check is performed.

<!--- (What does this Pull Request do? reference the related issue?) --->
Related issue: https://github.com/akeneo/transporteo/issues/125

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
