### PR TITLE
Fix source PIM version check to allow ^1.7 or ~1.7 or similar

### DIFF
--- a/src/Domain/Pim/SourcePim.php
+++ b/src/Domain/Pim/SourcePim.php
@@ -134,6 +134,6 @@ class SourcePim extends AbstractPim implements Pim
 
     protected static function getPimVersionAllowed(): string
     {
-        return  '1.7.';
+        return  '1.7';
     }
 }


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
The source Pim version check verify that the version string on composer.json container the "1.7." string.

But when the version string is like "^1.7", which means ">= 1.7 < 2.0" and so is perfectly valid, because it confirms that the source pim is a 1.7.x version, the check doesn't work because it doesn't contain a 1.7.* version string.

This check should allow ^1.7 or ~1.7 as source pim version, that's why it should only check for "1.7"

<!--- (What does this Pull Request do? reference the related issue?) --->

Related issue: https://github.com/akeneo/transporteo/issues/145

**Definition Of Done**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
